### PR TITLE
python: add kdumpfile wrapper

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -19,12 +19,12 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-kdumpfiledir = $(pkgpythondir)
+pykdumpfiledir = $(pythondir)/kdumpfile
 
 pyexec_LTLIBRARIES = _kdumpfile.la
+pykdumpfile_DATA = __init__.py
 
 _kdumpfile_la_SOURCES = kdumpfile.c
 _kdumpfile_la_CPPFLAGS = $(PYTHON_CFLAGS) -I$(top_srcdir)/src
 _kdumpfile_la_LDFLAGS = -module -avoid-version -export-symbols-regex init_kdumpfile
 _kdumpfile_la_LIBADD = $(top_builddir)/src/libkdumpfile.la
-

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+from _kdumpfile import *


### PR DESCRIPTION
This adds a wrapper to _kdumpfile so that we can extend the interface
with python as well as C.  Initially, it imports all symbols from the
_kdumpfile object.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>