### PR TITLE
python: add Makefile hooks to install python code

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -25,3 +25,5 @@ _kdumpfile_la_SOURCES = kdumpfile.c
 _kdumpfile_la_CPPFLAGS = $(PYTHON_CFLAGS) -I$(top_srcdir)/src
 _kdumpfile_la_LDFLAGS = -module -avoid-version -export-symbols-regex init_kdumpfile
 _kdumpfile_la_LIBADD = $(top_builddir)/src/libkdumpfile.la
+
+SUBDIRS = kdumpfile

--- a/python/kdumpfile/Makefile.am
+++ b/python/kdumpfile/Makefile.am
@@ -21,4 +21,4 @@
 
 pykdumpfiledir = $(pythondir)/kdumpfile
 
-pykdumpfile_DATA = __init__.py
+pykdumpfile_DATA = __init__.py exceptions.py


### PR DESCRIPTION
I missed adding the Makefile.am hooks to install the python code
to the site directory during `make install'.  This patch adds them.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>