### PR TITLE
python: add support for kdump_busy and kdump_addrxlat exception

### DIFF
--- a/python/kdumpfile.c
+++ b/python/kdumpfile.c
@@ -18,6 +18,8 @@ static PyObject *DataErrException;
 static PyObject *InvalidException;
 static PyObject *NoKeyException;
 static PyObject *EOFException;
+static PyObject *BusyException;
+static PyObject *AddressTranslationException;
 
 static PyTypeObject attr_dir_object_type;
 static PyTypeObject attr_iterkey_object_type;
@@ -43,6 +45,8 @@ exception_map(kdump_status status)
 	case kdump_invalid:     return InvalidException;
 	case kdump_nokey:       return NoKeyException;
 	case kdump_eof:         return EOFException;
+	case kdump_busy:	return BusyException;
+	case kdump_addrxlat:	return AddressTranslationException;
 	/* If we raise an exception with status == kdump_ok, it's a bug. */
 	case kdump_ok:
 	default:                return PyExc_RuntimeError;
@@ -328,6 +332,8 @@ cleanup_exceptions(void)
 	Py_XDECREF(InvalidException);
 	Py_XDECREF(NoKeyException);
 	Py_XDECREF(EOFException);
+	Py_XDECREF(BusyException);
+	Py_XDECREF(AddressTranslationException);
 }
 
 static int lookup_exceptions (void)
@@ -350,6 +356,8 @@ do {							\
 	lookup_exception(InvalidException);
 	lookup_exception(NoKeyException);
 	lookup_exception(EOFException);
+	lookup_exception(BusyException);
+	lookup_exception(AddressTranslationException);
 #undef lookup_exception
 
 	Py_XDECREF(mod);

--- a/python/kdumpfile/exceptions.py
+++ b/python/kdumpfile/exceptions.py
@@ -9,6 +9,8 @@ KDUMP_DATAERR     = 4
 KDUMP_INVALID     = 5
 KDUMP_NOKEY       = 6
 KDUMP_EOF         = 7
+KDUMP_BUSY        = 8
+KDUMP_ADDRXLAT    = 9
 
 class KDumpBaseException(Exception):
     error = None
@@ -33,3 +35,9 @@ class NoKeyException(KDumpBaseException):
 
 class EOFException(KDumpBaseException):
     error = KDUMP_EOF
+
+class BusyException(KDumpBaseException):
+    error = KDUMP_BUSY
+
+class AddressTranslationException(KDumpBaseException):
+    error = KDUMP_ADDRXLAT


### PR DESCRIPTION
There were two new exceptions added to kdump but without matching
python support.  As a result those get raised as RuntimeError exceptions
and can't be used to handle errors gracefully.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>