### PR TITLE
python: open target file in read-only mode

### DIFF
--- a/python/kdumpfile.c
+++ b/python/kdumpfile.c
@@ -123,7 +123,7 @@ kdumpfile_new (PyTypeObject *type, PyObject *args, PyObject *kw)
 		goto fail;
 	}
 
-	self->fd = open (filepath, O_RDWR);
+	self->fd = open (filepath, O_RDONLY);
 	if (self->fd < 0) {
 		PyErr_Format(OSErrorException, "Couldn't open dump file");
 		goto fail;


### PR DESCRIPTION
The python code won't write to the dump image, so we don't need to open
it in read-write mode.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>