### PR TITLE
addrxlat/python: add Makefile for installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,7 @@ AC_CONFIG_FILES([
 	src/addrxlat/Makefile
 	python/Makefile
 	python/kdumpfile/Makefile
+	python/addrxlat/Makefile
 	tests/Makefile
 	libaddrxlat.pc
 	libkdumpfile.pc

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -49,4 +49,4 @@ TESTS = \
 	test_addrxlat.py
 LOG_COMPILER = $(PYTHON)
 
-SUBDIRS = kdumpfile
+SUBDIRS = kdumpfile addrxlat

--- a/python/addrxlat/Makefile.am
+++ b/python/addrxlat/Makefile.am
@@ -1,0 +1,26 @@
+## Process this file with automake to create Makefile.in
+## Configure input file for libkdumpfile.
+##
+## Copyright (C) 2017 Ales Novak <alnovak@suse.cz>
+##
+## This file is part of libkdumpfile.
+##
+## This file is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## libkdumpfile is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+##
+
+pyaddrxlatdir = $(pythondir)/addrxlat
+
+pyaddrxlat_PYTHON = \
+	 __init__.py \
+	exceptions.py


### PR DESCRIPTION
The addrxlat C modules are properly installed but the python files need
to be installed as well.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>