### PR TITLE
devmem: include <sys/sysmacros.h> for makedev() and friends

### DIFF
--- a/src/kdumpfile/devmem.c
+++ b/src/kdumpfile/devmem.c
@@ -42,6 +42,7 @@
 #include <endian.h>
 #include <signal.h>
 #include <ucontext.h>
+#include <sys/sysmacros.h>
 
 #define FN_VMCOREINFO	"/sys/kernel/vmcoreinfo"
 #define FN_IOMEM	"/proc/iomem"


### PR DESCRIPTION
glibc-2.28 stopped including sys/sysmacros.h from sys/types.h so
we'll need it explicitly now.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>