### PR TITLE
python: fix use-after-free with addrxlat.Context callbacks

### DIFF
--- a/python/addrxlat.c
+++ b/python/addrxlat.c
@@ -1561,6 +1561,8 @@ install_cb_hook(ctx_object *self, addrxlat_cb_t *cb)
 	cb->sym = cb_sym;
 	cb->read32 = cb_read32;
 	cb->read64 = cb_read64;
+
+	Py_INCREF((PyObject *)self);
 }
 
 static void
@@ -1573,6 +1575,8 @@ cb_hook(void *_self, addrxlat_cb_t *cb)
 
 	if (self->ctx)
 		install_cb_hook(self, cb);
+
+	Py_DECREF((PyObject *)self);
 }
 
 PyDoc_STRVAR(ctx__doc__,


### PR DESCRIPTION
We keep a pointer to the Context object as the callback data pointer
but don't take a reference to it.  Later, after the Context object
has all references dropped from within Python and is garbage collected,
the callback can fire and we get a use-after-free.

This commit fixes it by taking a reference in install_cb_hook and
releasing it in cb_hook.

Signed-off-by: Jeff Mahoney <jeffm@suse.com>