### PR TITLE
Fix: kdump_vmcoreinfo_raw() causes rw deadlocks

### DIFF
--- a/src/kdumpfile/vmcoreinfo.c
+++ b/src/kdumpfile/vmcoreinfo.c
@@ -292,7 +292,7 @@ kdump_vmcoreinfo_raw(kdump_ctx_t *ctx, const char **raw)
 
 	ret = get_raw_locked(ctx, raw);
 
-	rwlock_rdlock(&ctx->shared->lock);
+	rwlock_unlock(&ctx->shared->lock);
 	return ret;
 }
 


### PR DESCRIPTION
While working on something I'd see my program hanging at `kdump_free()`. Within that function my program was stuck trying to acquire the lock as a writer. Inspecting the lock with gdb I saw that the `__readers` counter was bigger than 0 which implied that at least one reader forgot to drop the lock. I created a minimum reproduced of my program that looked like this:
```
int
main(int c, char *v[])
{
	if (c != 2)
		return (-1);

	int fd = open(v[1], O_RDONLY);
	assert(fd != -1);

	kdump_ctx_t *ctx = kdump_new();
	assert(ctx != NULL);

	kdump_status ks = kdump_set_number_attr(ctx, KDUMP_ATTR_FILE_FD, fd);
	assert (ks == KDUMP_OK);

	ks = kdump_set_string_attr(ctx, KDUMP_ATTR_OSTYPE, "linux");
	assert(ks == KDUMP_OK);

	const char *vmcoreinfo;
	ks = kdump_vmcoreinfo_raw(ctx, &vmcoreinfo);
	assert(ks == KDUMP_OK);

	kdump_free(ctx);

	return (0);
}
```

Using stock bits the program would hang here:
```
#0  0x00007f6f462969e4 in futex_abstimed_wait (private=<optimized out>, abstime=0x0, expected=2, futex_word=0x559c991656f8) at ../sysdeps/unix/sysv/linux/futex-internal.h:172
#1  __pthread_rwlock_wrlock_full (abstime=0x0, rwlock=0x559c991656f0) at pthread_rwlock_common.c:803
#2  __GI___pthread_rwlock_wrlock (rwlock=rwlock@entry=0x559c991656f0) at pthread_rwlock_wrlock.c:27
#3  0x00007f6f46ef1ec4 in rwlock_wrlock (rwlock=0x559c991656f0) at ../threads.h:96
#4  kdump_free (ctx=0x559c99165260) at open.c:302
#5  0x0000559c9719faa2 in main ()
```

With the bits from this PR, the program would exit successfully.