### PR TITLE
libkdumpfile: aarch64 linux vmcore support

### DIFF
--- a/include/libkdumpfile/addrxlat.h.in
+++ b/include/libkdumpfile/addrxlat.h.in
@@ -263,6 +263,14 @@ typedef enum _addrxlat_sym_type {
 	 * - @c val = @c offsetof(args[0],args[1])
 	 */
 	ADDRXLAT_SYM_OFFSETOF,
+
+	/** Number value.
+	 * Input:
+	 * - @c args[0] = number name
+	 * Output:
+	 * - @c val = number value
+	 */
+	ADDRXLAT_SYM_NUMBER,
 } addrxlat_sym_type_t;
 
 /** Maximum argument count for @ref addrxlat_sym_t. */
@@ -281,6 +289,7 @@ addrxlat_sym_argc(addrxlat_sym_type_t type)
 	case ADDRXLAT_SYM_REG:
 	case ADDRXLAT_SYM_VALUE:
 	case ADDRXLAT_SYM_SIZEOF:
+	case ADDRXLAT_SYM_NUMBER:
 		return 1;
 
 	case ADDRXLAT_SYM_OFFSETOF:

--- a/src/addrxlat/aarch64.c
+++ b/src/addrxlat/aarch64.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 
 #include "addrxlat-priv.h"
+#include <linux/version.h>
 
 /* Maximum physical address bits (architectural limit) */
 #define PA_MAX_BITS	48
@@ -139,4 +140,202 @@ pgt_aarch64(addrxlat_step_t *step)
 		step->elemsz = 1;
 
 	return ADDRXLAT_OK;
+}
+
+#define is_linear_addr(addr, kernel_ver, va_bits)		   \
+	(((kernel_ver) < KERNEL_VERSION(5, 4, 0)) ?		   \
+	 (!!((unsigned long)(addr) & (1UL << ((va_bits) - 1)))) :  \
+	 (!((unsigned long)(addr) & (1UL << ((va_bits) - 1)))))
+
+static unsigned long
+get_page_offset(unsigned long kernel_ver, addrxlat_addr_t va_bits) {
+	unsigned long page_offset;
+
+	if (kernel_ver < KERNEL_VERSION(5, 4, 0))
+		page_offset = ((0xffffffffffffffffUL) -
+				((1UL) << (va_bits - 1)) + 1);
+	else
+		page_offset = (-(1UL << va_bits));
+	return page_offset;
+}
+
+/** Determine Linux page table root.
+ * @param ctl	     Initialization data.
+ * @param[out] root  Page table root address (set on successful return).
+ * @returns	     Error status.
+ */
+static addrxlat_status
+get_linux_pgtroot(struct os_init_data *ctl, addrxlat_fulladdr_t *root)
+{
+	addrxlat_status status;
+	addrxlat_addr_t root_va;
+
+	addrxlat_addr_t va_bits;
+	addrxlat_addr_t phys_base;
+	addrxlat_addr_t kimage_voffset;
+	int no_kimage_voffset = 0;
+
+	unsigned long page_offset;
+	unsigned long kernel_ver;
+
+
+	status = get_symval(ctl->ctx, "swapper_pg_dir",
+			    &root_va);
+	if (status != ADDRXLAT_OK)
+		return set_error(ctl->ctx, status,
+				 "Cannot determine page table virtual address");
+
+	/*
+	 * This code will only work with vmcores produced by
+	 * Linux Kernel versions 4.12 and above. Makedumpfile
+	 * for kernels before 4.12 uses a heuristic based on
+	 * reading vmcore load segment addressess and finds
+	 * va_bits and phys_offset. This code does not support
+	 * such logic.
+	 */
+	status = get_number(ctl->ctx, "VA_BITS",
+			    &va_bits);
+	if (status != ADDRXLAT_OK)
+		return set_error(ctl->ctx, status,
+				 "Cannot determine VA_BITS");
+
+	status = get_number(ctl->ctx, "kimage_voffset" ,
+			    &kimage_voffset);
+	if (status != ADDRXLAT_OK)
+		 no_kimage_voffset = 1;
+
+	kernel_ver = ctl->osdesc->ver;
+
+
+	if (no_kimage_voffset || is_linear_addr(root_va, kernel_ver, va_bits)) {
+		status = get_number(ctl->ctx, "PHYS_OFFSET" ,
+				    &phys_base);
+		if (status != ADDRXLAT_OK)
+			return set_error(ctl->ctx, status,
+				 "Cannot determine PHYS_OFFSET");
+
+		page_offset = get_page_offset(kernel_ver, va_bits);
+
+		if (kernel_ver < KERNEL_VERSION(5, 4, 0)) {
+			 root->addr = ((root_va & ~page_offset) + phys_base);
+		} else {
+			 root->addr =  (root_va + phys_base - page_offset);
+		}
+	} else {
+	    root->addr = root_va - kimage_voffset;
+	}
+
+	root->as =  ADDRXLAT_KPHYSADDR;
+
+	return ADDRXLAT_OK;
+}
+
+/* Maximum physical address bits (architectural limit) */
+#define PHYSADDR_BITS_MAX	52
+#define PHYSADDR_MASK		ADDR_MASK(PHYSADDR_BITS_MAX)
+#define VIRTADDR_MAX		UINT64_MAX
+
+
+/** Initialize a translation map for Linux/aarch64.
+ * @param ctl  Initialization data.
+ * @returns	  Error status.
+ */
+static addrxlat_status
+map_linux_aarch64(struct os_init_data *ctl)
+{
+	static const addrxlat_paging_form_t aarch64_pf = {
+		.pte_format = ADDRXLAT_PTE_AARCH64,
+		.nfields = 5,
+		.fieldsz = { 12, 9, 9, 9, 9, 9 }
+	};
+
+	/*
+	 * Generic aarch64 layout, depends on current va_bits
+	 *
+	 * Aarch64 kernel does have a linear mapping region, the location
+	 * of which changed in the 5.4 kernel. But since it is covered
+	 * by swapper pgt anyway we don't bother to reflect it here.
+	 */
+	struct sys_region aarch64_layout_generic[] = {
+	    {  0,  0,			/* lower half	    */
+	       ADDRXLAT_SYS_METH_PGT },
+
+	    {  0,  VIRTADDR_MAX,	 /* higher half	     */
+	       ADDRXLAT_SYS_METH_PGT },
+	    SYS_REGION_END
+	};
+
+	addrxlat_map_t *map;
+	addrxlat_meth_t *meth;
+	addrxlat_status status;
+	addrxlat_addr_t va_bits;
+
+	meth = &ctl->sys->meth[ADDRXLAT_SYS_METH_PGT];
+	meth->kind = ADDRXLAT_PGT;
+	meth->target_as = ADDRXLAT_MACHPHYSADDR;
+
+	if (ctl->popt.val[OPT_rootpgt].set)
+		meth->param.pgt.root = ctl->popt.val[OPT_rootpgt].fulladdr;
+	else {
+		status = get_linux_pgtroot(ctl, &meth->param.pgt.root);
+		if (status != ADDRXLAT_OK)
+			return status;
+	}
+
+	meth->param.pgt.pte_mask =
+		opt_num_default(&ctl->popt, OPT_pte_mask, 0);
+	meth->param.pgt.pf = aarch64_pf;
+
+	status = get_number(ctl->ctx, "VA_BITS",
+			    &va_bits);
+	if (status != ADDRXLAT_OK)
+		return set_error(ctl->ctx, status,
+				 "Cannot determine VA_BITS");
+
+	if (ctl->popt.val[OPT_levels].set) {
+		long levels = ctl->popt.val[OPT_levels].num;
+		if (levels < 3 || levels > 5)
+			return bad_paging_levels(ctl->ctx, levels);
+		meth->param.pgt.pf.nfields = levels + 1;
+	} else
+		meth->param.pgt.pf.nfields = ((va_bits - 12) / 9) + 1;
+
+	/* layout depends on current value of va_bits */
+	aarch64_layout_generic[0].last =  ~(-(1ull) << (va_bits));
+	aarch64_layout_generic[1].first =  (-(1ull) << (va_bits));
+
+	status = sys_set_layout(ctl, ADDRXLAT_SYS_MAP_HW,
+				aarch64_layout_generic);
+	if (status != ADDRXLAT_OK)
+		return status;
+
+	map = internal_map_copy(ctl->sys->map[ADDRXLAT_SYS_MAP_HW]);
+	if (!map)
+		return set_error(ctl->ctx, ADDRXLAT_ERR_NOMEM,
+				 "Cannot duplicate hardware mapping");
+	ctl->sys->map[ADDRXLAT_SYS_MAP_KV_PHYS] = map;
+
+	status = sys_set_physmaps(ctl, PHYSADDR_MASK);
+	if (status != ADDRXLAT_OK)
+		return status;
+
+	return ADDRXLAT_OK;
+}
+
+
+/** Initialize a translation map for an aarch64 OS.
+ * @param ctl  Initialization data.
+ * @returns    Error status.
+ */
+addrxlat_status
+sys_aarch64(struct os_init_data *ctl)
+{
+	switch (ctl->osdesc->type) {
+	case ADDRXLAT_OS_LINUX:
+		return map_linux_aarch64(ctl);
+
+	default:
+		return set_error(ctl->ctx, ADDRXLAT_ERR_NOTIMPL,
+				 "OS type not implemented");
+	}
 }

--- a/src/addrxlat/addrxlat-priv.h
+++ b/src/addrxlat/addrxlat-priv.h
@@ -460,6 +460,8 @@ struct os_init_data {
  */
 typedef addrxlat_status sys_arch_fn(struct os_init_data *ctl);
 
+INTERNAL_DECL(sys_arch_fn, sys_aarch64, );
+
 INTERNAL_DECL(sys_arch_fn, sys_ia32, );
 
 INTERNAL_DECL(sys_arch_fn, sys_ppc64, );

--- a/src/addrxlat/addrxlat-priv.h
+++ b/src/addrxlat/addrxlat-priv.h
@@ -178,6 +178,9 @@ INTERNAL_DECL(addrxlat_status, get_offsetof,
 	      (addrxlat_ctx_t *ctx, const char *type, const char *memb,
 	       addrxlat_addr_t *off));
 
+INTERNAL_DECL(addrxlat_status, get_number,
+	      (addrxlat_ctx_t *ctx, const char *name, addrxlat_addr_t *num));
+
 /** Maximum symbol specifier name length. */
 #define SYM_SPEC_NAMELEN 24
 

--- a/src/addrxlat/ctx.c
+++ b/src/addrxlat/ctx.c
@@ -546,6 +546,36 @@ get_offsetof(addrxlat_ctx_t *ctx, const char *type, const char *memb,
 	return status;
 }
 
+/** Resolve a number value.
+ * @param      ctx   Address translation context.
+ * @param      name  Number name.
+ * @param[out] num   Number value returned on success.
+ * @returns	     Error status.
+ *
+ * The size is determined using a user-supplied callback.
+ */
+addrxlat_status
+get_number(addrxlat_ctx_t *ctx, const char *name, addrxlat_addr_t *num)
+{
+	addrxlat_sym_t sym;
+	addrxlat_status status;
+
+	if (!ctx->cb.sym)
+		return set_error(ctx, ADDRXLAT_ERR_NODATA,
+				 "No symbolic information callback");
+
+	sym.type = ADDRXLAT_SYM_NUMBER;
+	sym.args[0] = name;
+	status = ctx->cb.sym(ctx->cb.data, &sym);
+	if (status != ADDRXLAT_OK)
+		return set_error(ctx, status, "Cannot get number(%s)",
+				 sym.args[0]);
+
+	*num = sym.val;
+	return status;
+}
+
+
 /** Get the first successfuly resolved value from a specifier list.
  * @param      ctx   Address translation context.
  * @param      spec  Vector of specifiers.

--- a/src/addrxlat/sys.c
+++ b/src/addrxlat/sys.c
@@ -98,6 +98,8 @@ addrxlat_sys_os_init(addrxlat_sys_t *sys, addrxlat_ctx_t *ctx,
 		arch_fn = sys_s390x;
 	else if (!strcmp(osdesc->arch, "ppc64"))
 		arch_fn = sys_ppc64;
+	else if (!strcmp(osdesc->arch, "aarch64"))
+		arch_fn = sys_aarch64;
 	else
 		return set_error(ctx, ADDRXLAT_ERR_NOTIMPL,
 				"Unsupported architecture");

--- a/src/kdumpfile/vtop.c
+++ b/src/kdumpfile/vtop.c
@@ -578,6 +578,12 @@ addrxlat_sym(void *data, addrxlat_sym_t *sym)
 		{ ADDRXLAT_OS_UNKNOWN }
 	};
 
+	static const struct ostype_attr_map number_map[] = {
+		{ ADDRXLAT_OS_LINUX, GKI_linux_number },
+		{ ADDRXLAT_OS_XEN, GKI_xen_number },
+		{ ADDRXLAT_OS_UNKNOWN }
+	};
+
 	kdump_ctx_t *ctx = (kdump_ctx_t*) data;
 	const struct attr_data *base;
 	struct attr_data *attr;
@@ -602,6 +608,14 @@ addrxlat_sym(void *data, addrxlat_sym_t *sym)
 
 	case ADDRXLAT_SYM_OFFSETOF:
 		base = ostype_attr(ctx, offsetof_map);
+		if (!base)
+			return addrxlat_ctx_err(
+				ctx->xlatctx, ADDRXLAT_ERR_NOTIMPL,
+				"Unsupported OS");
+		break;
+
+        case ADDRXLAT_SYM_NUMBER:
+		base = ostype_attr(ctx, number_map);
 		if (!base)
 			return addrxlat_ctx_err(
 				ctx->xlatctx, ADDRXLAT_ERR_NOTIMPL,


### PR DESCRIPTION
Hi Petr,

Could you please merge these changes in libkdumpfile to support aarch64 linux vmcore. It was tested using OpenEmbedded qemuearm64 machine alongside with corresponding crash-python changes [1]. I tested it on 5.8 and 5.2 kernel vmcores. I have tried nokaslr, kaslr, 39 and 48 va_bits. For reference my meta-kcrash OpenEmbedded layer that integrates libkdumpfile and crash-python into OpenEmbedded could be found here [2].

[1] https://github.com/AlexanderKamensky/crash-python
[2] https://github.com/AlexanderKamensky/meta-kcrash

Thanks,
Alexander