### PR TITLE
python: fix inconsistency in allocation/dellocation of blob and bmp o…

### DIFF
--- a/python/kdumpfile.c
+++ b/python/kdumpfile.c
@@ -1726,7 +1726,7 @@ bmp_new(kdump_bmp_t *bmp)
 {
 	bmp_object *self;
 
-	self = PyObject_GC_New(bmp_object, &bmp_object_type);
+	self = PyObject_New(bmp_object, &bmp_object_type);
 	if (!self)
 		return NULL;
 
@@ -1907,7 +1907,7 @@ blob_new(kdump_blob_t *blob)
 {
 	blob_object *self;
 
-	self = PyObject_GC_New(blob_object, &blob_object_type);
+	self = PyObject_New(blob_object, &blob_object_type);
 	if (!self)
 		return NULL;
 


### PR DESCRIPTION
Hi Petr,

Could you please merge this small patch. I ran into an issue when I played around with kdump attributes.

When running the following python code that dumps all attributes of kdump object it crashes with SIGSEGV.

```
import sys
from kdumpfile import kdumpfile, attr_dir

def read_attrs(list_attrs, cont):
    for k in list_attrs.keys():
        if isinstance(list_attrs[k], attr_dir):
            newcont = cont + '["' + str(k) + '"]'
            read_attrs(list_attrs[k], newcont) 
        else:
            print(cont +'["'+ str(k) + '"] = ' + str(list_attrs[k]))

def main():
    kdump = kdumpfile(file=sys.argv[1])
    read_attrs(kdump.attr, "kdump.attr")
    
main()
```

Running it:

```
[skamensk@localhost libkdumpfile_attr_crash]$ python dumpallattrs.py /home/skamensk/crash-python/data/5.8/aarch64/v5smp/vmcore
kdump.attr["max_pfn"] = 458752
<snip>
kdump.attr["linux"]["vmcoreinfo"]["lines"]["PAGESIZE"] = 4096
kdump.attr["linux"]["vmcoreinfo"]["lines"]["OSRELEASE"] = 5.8.13-yocto-standard
kdump.attr["linux"]["uts"]["release"] = 5.8.13-yocto-standard
kdump.attr["linux"]["version_code"] = 329741
kdump.attr["file"]["pagemap"] = <_kdumpfile.bmp object at 0x7f89cb9e6230>
kdump.attr["file"]["fd"] = 3
kdump.attr["file"]["mmap_policy"] = 2
Segmentation fault (core dumped)

```
Python version:

```
[skamensk@localhost libkdumpfile_attr_crash]$ python --version
Python 3.8.6

```
Running it under valgrind switching from python malloc to regular malloc.

```
[skamensk@localhost libkdumpfile_attr_crash]$ export PYTHONMALLOC=malloc
[skamensk@localhost libkdumpfile_attr_crash]$ valgrind --tool=memcheck -s python dumpallattrs.py /home/skamensk/crash-python/data/5.8/aarch64/v5smp/vmcore
==343539== Memcheck, a memory error detector
==343539== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==343539== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==343539== Command: python dumpallattrs.py /home/skamensk/crash-python/data/5.8/aarch64/v5smp/vmcore
==343539== 
kdump.attr["max_pfn"] = 458752
kdump.attr["linux"]["vmcoreinfo"]["SYMBOL"]["log_next_idx"] = 18446743799118693444
kdump.attr["linux"]["vmcoreinfo"]["SYMBOL"]["clear_idx"] = 18446743799118693456

<snip>

kdump.attr["arch"]["machine"] = 183
kdump.attr["arch"]["name"] = aarch64
kdump.attr["arch"]["pteval_size"] = 8
==343539== 
==343539== HEAP SUMMARY:
==343539==     in use at exit: 9,547,378 bytes in 8,911 blocks
==343539==   total heap usage: 85,812 allocs, 76,913 frees, 25,121,859 bytes allocated
==343539== 
==343539== LEAK SUMMARY:
==343539==    definitely lost: 19,666 bytes in 353 blocks
==343539==    indirectly lost: 0 bytes in 0 blocks
==343539==      possibly lost: 133,724 bytes in 1,688 blocks
==343539==    still reachable: 9,393,988 bytes in 6,870 blocks
==343539==         suppressed: 0 bytes in 0 blocks
==343539== Rerun with --leak-check=full to see details of leaked memory
==343539== 
==343539== ERROR SUMMARY: 12 errors from 1 contexts (suppressed: 0 from 0)
==343539== 
==343539== 12 errors in context 1 of 1:
==343539== Invalid free() / delete / delete[] / realloc() <---------------
==343539==    at 0x483B9F5: free (vg_replace_malloc.c:538)
==343539==    by 0x4B448AA: UnknownInlinedFun (object.c:2215)
==343539==    by 0x4B448AA: UnknownInlinedFun (object.h:478)
==343539==    by 0x4B448AA: UnknownInlinedFun (ceval.c:4971)
==343539==    by 0x4B448AA: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B43323: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B43323: _PyEval_EvalCodeWithName (ceval.c:4298)
==343539==    by 0x4BBEB68: PyEval_EvalCodeEx (ceval.c:4327)
==343539==  Address 0x132941a0 is 16 bytes inside a block of size 40 alloc'd <------
==343539==    at 0x483A809: malloc (vg_replace_malloc.c:307)
==343539==    by 0x4B342EF: UnknownInlinedFun (obmalloc.c:685)
==343539==    by 0x4B342EF: _PyObject_GC_Alloc (gcmodule.c:1964)
==343539==    by 0x4B349A4: UnknownInlinedFun (gcmodule.c:1987)
==343539==    by 0x4B349A4: _PyObject_GC_New (gcmodule.c:1999)
==343539==    by 0x485C277: blob_new (kdumpfile.c:1910) <---------------------------
==343539==    by 0x485C277: attr_new (kdumpfile.c:218)
==343539==    by 0x485CD36: attr_dir_subscript (kdumpfile.c:571)
==343539==    by 0x4B44FF4: _PyEval_EvalFrameDefault (ceval.c:1584)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539==    by 0x4B52776: UnknownInlinedFun (ceval.c:741)
==343539==    by 0x4B52776: function_code_fastcall (call.c:283)
==343539==    by 0x4B4480C: UnknownInlinedFun (abstract.h:127)
==343539==    by 0x4B4480C: UnknownInlinedFun (ceval.c:4963)
==343539==    by 0x4B4480C: _PyEval_EvalFrameDefault (ceval.c:3500)
==343539== 
==343539== ERROR SUMMARY: 12 errors from 1 contexts (suppressed: 0 from 0)
[skamensk@localhost libkdumpfile_attr_crash]$ 
```

It complains that there blob_new() allocated 40 bytes while the free was called for an address 16 bytes inside this allocation. Note the size of blob_object is 24 bytes.

The issue is that blob_new uses PyObject_GC_New() to create new objects but blob_object_type does not have Py_TPFLAGS_HAVE_GC in its tp_flags. PyObject_GC_New() allocates additional memory for PyGC_Head (size 16) in front of PyObject and returns pointer to PyObject (FROM_GC(g)). On other hand because Py_TPFLAGS_HAVE_GC was not set in tp_flags of blob_object_type python installs PyObject_Free as tp_free. PyObject_Free when called just free PyObject pointer itself. The types that uses Py_TPFLAGS_HAVE_GC installs  PyObject_GC_Del as tp_free and it does adjust PyObject pointer to PYGC_Head (AS_GC(op)) before calling free. This inconsistency causes free in middle of previous allocation.  

Since blob_object_type is not a container it doesn't need Py_TPFLAGS_HAVE_GC flag, but it needs to use PyObject_New() to allocate the object.

The same issue exists with bmp object.