### PR TITLE
Resolve missing UINT_MAX declaration

### DIFF
--- a/src/kdumpfile/util.c
+++ b/src/kdumpfile/util.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <limits.h>
 
 #if USE_ZLIB
 # include <zlib.h>


### PR DESCRIPTION
On an older system with gcc 4.8.5, building libkdumpfile 0.4.1 results
in the following error:

util.c: In function ‘cache_size_pre_hook’:
util.c:580:20: error: ‘UINT_MAX’ undeclared (first use in this function)
  if (val->number > UINT_MAX)
                    ^
util.c:580:20: note: each undeclared identifier is reported only once for each function it appears in

Resolve this error by including "limits.h"

Signed-off-by: Stephen Brennan <stephen@brennan.io>