### PR TITLE
devmem: fix duplicate xen_cpuid_ud and xen_cpuid_ret symbols on GCC 12

### DIFF
--- a/src/kdumpfile/devmem.c
+++ b/src/kdumpfile/devmem.c
@@ -84,6 +84,7 @@ xen_sigill(int sig, siginfo_t *si, void *ucontext)
 	}
 }
 
+__attribute__((__noipa__))
 static int
 xen_cpuid(uint32_t leaf, uint32_t subleaf,
 	  uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)


### PR DESCRIPTION
Fedora 36 ran into the following build error:

```
devmem.c: Assembler messages:
devmem.c:94: Error: symbol `xen_cpuid_ud' is already defined
devmem.c:99: Error: symbol `xen_cpuid_ret' is already defined
```

See https://src.fedoraproject.org/rpms/libkdumpfile/pull-request/1.

This happens because GCC 12 inlines xen_cpuid() into is_xen_pv() and
unrolls the first iteration of the loop in is_xen_pv(). This results in
the xen_cpuid() asm statement containing the symbol definitions being
duplicated.

Fix it by adding `__attribute__((__noipa__))` to xen_cpuid(), which ensures
that there will only be one instance. (noinline is theoretically not
enough because the function could still be cloned due to constant
propagation, and noclone is not enough because it has no effect if the
function is inlined. noinline,noclone might be enough, but at that point
we might as well prevent any other shenanigans.)

Here is an assembly dump of the code generated by GCC 12: https://gist.github.com/osandov/391f874414f82838104337d18a0a148b. Let me know if you know of a better workaround.