### PR TITLE
Fix Python tests for Python 3.11

### DIFF
--- a/python/test_addrxlat.py
+++ b/python/test_addrxlat.py
@@ -290,11 +290,11 @@ class TestMethod(unittest.TestCase):
             meth.tbl = ((1,),)
         with self.assertRaisesRegexp(ValueError, 'must be integer pairs'):
             meth.tbl = ((1, 2, 3),)
-        with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
+        with self.assertRaisesRegexp(TypeError, 'must be.* a .*number'):
             meth.tbl = ((None, None),)
-        with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
+        with self.assertRaisesRegexp(TypeError, 'must be.* a .*number'):
             meth.tbl = ((1, None),)
-        with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
+        with self.assertRaisesRegexp(TypeError, 'must be.* a .*number'):
             meth.tbl = ((None, 1),)
 
     def test_memarr_defaults(self):
@@ -592,7 +592,7 @@ class TestStep(unittest.TestCase):
             step.idx = None
         with self.assertRaisesRegexp(ValueError, 'more than [0-9]+ indices'):
             step.idx = (0,) * (addrxlat.FIELDS_MAX + 2)
-        with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
+        with self.assertRaisesRegexp(TypeError, 'must be.* a .*number'):
             step.idx = (None,)
 
 class TestOperator(unittest.TestCase):


### PR DESCRIPTION
The exception raised has changed:

```
======================================================================
FAIL: test_lookup_tbl (__main__.TestMethod.test_lookup_tbl)
----------------------------------------------------------------------
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/libkdumpfile-4829feb8a46e76ac2f2bc98f47b2f3f1d32300df/python/./test_addrxlat.py", line 293, in test_lookup_tbl
    with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
AssertionError: "must be.* a number" does not match "int() argument must be a string, a bytes-like object or a real number, not 'NoneType'"

======================================================================
FAIL: test_step_idx (__main__.TestStep.test_step_idx)
----------------------------------------------------------------------
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/libkdumpfile-4829feb8a46e76ac2f2bc98f47b2f3f1d32300df/python/./test_addrxlat.py", line 595, in test_step_idx
    with self.assertRaisesRegexp(TypeError, 'must be.* a number'):
AssertionError: "must be.* a number" does not match "int() argument must be a string, a bytes-like object or a real number, not 'NoneType'"
```

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>