### PR TITLE
Fix xlat test shells

### DIFF
--- a/tests/xlat-linux-aarch64-5.16-64k
+++ b/tests/xlat-linux-aarch64-5.16-64k
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 5.16 AArch64 translation with 48-bit virtual addresses

--- a/tests/xlat-linux-aarch64-5.2-va39
+++ b/tests/xlat-linux-aarch64-5.2-va39
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 5.2 AArch64 translation with 39-bit virtual addresses

--- a/tests/xlat-linux-aarch64-5.8-va39
+++ b/tests/xlat-linux-aarch64-5.8-va39
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 5.8 AArch64 translation with 39-bit virtual addresses

--- a/tests/xlat-linux-aarch64-5.8-va48
+++ b/tests/xlat-linux-aarch64-5.8-va48
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 5.8 AArch64 translation with 48-bit virtual addresses

--- a/tests/xlat-linux-aarch64-5.8-va48-nover
+++ b/tests/xlat-linux-aarch64-5.8-va48-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 5.8 AArch64 translation with 48-bit virtual addresses

--- a/tests/xlat-linux-ia32
+++ b/tests/xlat-linux-ia32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux IA32 translation

--- a/tests/xlat-linux-ia32-pae
+++ b/tests/xlat-linux-ia32-pae
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux IA32 PAE translation

--- a/tests/xlat-linux-ppc64-64k
+++ b/tests/xlat-linux-ppc64-64k
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 64k page PPC64 translation

--- a/tests/xlat-linux-s390x-2l
+++ b/tests/xlat-linux-s390x-2l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 2-level Linux s390x translation

--- a/tests/xlat-linux-s390x-3l
+++ b/tests/xlat-linux-s390x-3l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 2-level Linux s390x translation

--- a/tests/xlat-linux-s390x-4l
+++ b/tests/xlat-linux-s390x-4l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 2-level Linux s390x translation

--- a/tests/xlat-linux-x86_64-2.6.11
+++ b/tests/xlat-linux-x86_64-2.6.11
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.11 X86_64 translation

--- a/tests/xlat-linux-x86_64-2.6.11-nover
+++ b/tests/xlat-linux-x86_64-2.6.11-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.11 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.27
+++ b/tests/xlat-linux-x86_64-2.6.27
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.27 X86_64 translation

--- a/tests/xlat-linux-x86_64-2.6.27-cr3-xen
+++ b/tests/xlat-linux-x86_64-2.6.27-cr3-xen
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.27 under Xen X86_64 translation without explicit

--- a/tests/xlat-linux-x86_64-2.6.27-nover
+++ b/tests/xlat-linux-x86_64-2.6.27-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.27 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.31
+++ b/tests/xlat-linux-x86_64-2.6.31
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation

--- a/tests/xlat-linux-x86_64-2.6.31-cr3
+++ b/tests/xlat-linux-x86_64-2.6.31-cr3
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.31-kvaddr
+++ b/tests/xlat-linux-x86_64-2.6.31-kvaddr
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation with data access through

--- a/tests/xlat-linux-x86_64-2.6.31-nover
+++ b/tests/xlat-linux-x86_64-2.6.31-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.31-nover-reloc
+++ b/tests/xlat-linux-x86_64-2.6.31-nover-reloc
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.31-nover-xen
+++ b/tests/xlat-linux-x86_64-2.6.31-nover-xen
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-2.6.31-reloc
+++ b/tests/xlat-linux-x86_64-2.6.31-reloc
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation with relocated kernel

--- a/tests/xlat-linux-x86_64-4.12-sme
+++ b/tests/xlat-linux-x86_64-4.12-sme
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 4.12 X86_64 translation with SME active

--- a/tests/xlat-linux-x86_64-4.13-kaslr
+++ b/tests/xlat-linux-x86_64-4.13-kaslr
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 4.13 X86_64 translation with kASLR without explicit version,

--- a/tests/xlat-linux-x86_64-4.13-nover
+++ b/tests/xlat-linux-x86_64-4.13-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.31 X86_64 translation without explicit version,

--- a/tests/xlat-linux-x86_64-5l
+++ b/tests/xlat-linux-x86_64-5l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 5-level translation without explicit version,

--- a/tests/xlat-linux-x86_64-ktext-128M
+++ b/tests/xlat-linux-x86_64-ktext-128M
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 128M ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-130M
+++ b/tests/xlat-linux-x86_64-ktext-130M
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 130M ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-130M-nonlinear
+++ b/tests/xlat-linux-x86_64-ktext-130M-nonlinear
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 128M ktext mapping, followed

--- a/tests/xlat-linux-x86_64-ktext-1G
+++ b/tests/xlat-linux-x86_64-ktext-1G
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 1G ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-40M
+++ b/tests/xlat-linux-x86_64-ktext-40M
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 40M ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-512M
+++ b/tests/xlat-linux-x86_64-ktext-512M
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 512M ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-520M
+++ b/tests/xlat-linux-x86_64-ktext-520M
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with 520M ktext mapping

--- a/tests/xlat-linux-x86_64-ktext-crosspage
+++ b/tests/xlat-linux-x86_64-ktext-crosspage
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation where two Page Tables must

--- a/tests/xlat-linux-x86_64-ktext-pgt
+++ b/tests/xlat-linux-x86_64-ktext-pgt
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux X86_64 translation with ktext fallback to page tables

--- a/tests/xlat-linux-x86_64-old
+++ b/tests/xlat-linux-x86_64-old
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux pre-2.6.11 X86_64 translation

--- a/tests/xlat-linux-x86_64-old-nover
+++ b/tests/xlat-linux-x86_64-old-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Linux 2.6.11 X86_64 translation without explicit version,

--- a/tests/xlat-os-aarch64-none
+++ b/tests/xlat-os-aarch64-none
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check AArch64 translation with no OS

--- a/tests/xlat-os-ia32-none
+++ b/tests/xlat-os-ia32-none
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check IA32 translation with no OS

--- a/tests/xlat-os-ia32-pae-none
+++ b/tests/xlat-os-ia32-pae-none
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check IA32 PAE translation with no OS

--- a/tests/xlat-os-s390x-2l
+++ b/tests/xlat-os-s390x-2l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 2-level s390x translation with no OS

--- a/tests/xlat-os-s390x-3l
+++ b/tests/xlat-os-s390x-3l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 3-level s390x translation with no OS

--- a/tests/xlat-os-s390x-4l
+++ b/tests/xlat-os-s390x-4l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 4-level s390x translation with no OS

--- a/tests/xlat-os-s390x-5l
+++ b/tests/xlat-os-s390x-5l
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check 5-level s390x translation with no OS

--- a/tests/xlat-os-x86_64-none
+++ b/tests/xlat-os-x86_64-none
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check X86_64 translation with no OS

--- a/tests/xlat-xen-ia32
+++ b/tests/xlat-xen-ia32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen IA32 translation

--- a/tests/xlat-xen-ia32-pae
+++ b/tests/xlat-xen-ia32-pae
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen IA32 PAE translation

--- a/tests/xlat-xen-x86_64-3.2
+++ b/tests/xlat-xen-x86_64-3.2
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 3.2 X86_64 translation

--- a/tests/xlat-xen-x86_64-3.2-nover
+++ b/tests/xlat-xen-x86_64-3.2-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 3.2 X86_64 translation without explicit version,

--- a/tests/xlat-xen-x86_64-4.0
+++ b/tests/xlat-xen-x86_64-4.0
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.0 X86_64 translation

--- a/tests/xlat-xen-x86_64-4.0-nover
+++ b/tests/xlat-xen-x86_64-4.0-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.0 X86_64 translation without explicit version,

--- a/tests/xlat-xen-x86_64-4.0dev-nover
+++ b/tests/xlat-xen-x86_64-4.0dev-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.0 X86_64 translation without explicit version,

--- a/tests/xlat-xen-x86_64-4.3
+++ b/tests/xlat-xen-x86_64-4.3
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.3 X86_64 translation

--- a/tests/xlat-xen-x86_64-4.3-nover
+++ b/tests/xlat-xen-x86_64-4.3-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.3 X86_64 translation without explicit version,

--- a/tests/xlat-xen-x86_64-4.4
+++ b/tests/xlat-xen-x86_64-4.4
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.4 X86_64 translation

--- a/tests/xlat-xen-x86_64-4.4-nover
+++ b/tests/xlat-xen-x86_64-4.4-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.4 X86_64 translation without explicit version,

--- a/tests/xlat-xen-x86_64-4.6-bigmem
+++ b/tests/xlat-xen-x86_64-4.6-bigmem
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen 4.6 X86_64 BIGMEM translation without explicit version,

--- a/tests/xlat-xen-x86_64-old
+++ b/tests/xlat-xen-x86_64-old
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen pre-3.2 X86_64 translation

--- a/tests/xlat-xen-x86_64-old-nover
+++ b/tests/xlat-xen-x86_64-old-nover
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 #
 # Check Xen pre-3.2 X86_64 translation without explicit version,


### PR DESCRIPTION
These scripts contain Bashisms: `opts=(...)` that are not supported on
systems where `/bin/sh` is dash (Debian, Ubuntu).

Explicitly require `/bin/bash` instead.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>