### PR TITLE
Fix multixlat test linking on Debian and Ubuntu

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -84,6 +84,7 @@ dumpdata_LDADD = \
 multiread_LDADD = \
 	$(top_builddir)/src/kdumpfile/libkdumpfile.la
 multixlat_LDADD = \
+	$(top_builddir)/src/addrxlat/libaddrxlat.la \
 	$(top_builddir)/src/kdumpfile/libkdumpfile.la
 nometh_LDADD = \
 	$(top_builddir)/src/addrxlat/libaddrxlat.la


### PR DESCRIPTION
This needs to be linked against `libaddrxlat` as well because there is a
reference to `addrxlat_addrspace_name@@LIBADDRXLAT_0`.

Fixes #49.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>