### PR TITLE
Fix spelling errors

### DIFF
--- a/examples/dumpattr.c
+++ b/examples/dumpattr.c
@@ -58,7 +58,7 @@ print_bitmap(kdump_ctx_t *ctx, kdump_bmp_t *bmp)
 		kdump_addr_t start = idx;
 		status = kdump_bmp_find_clear(bmp, &idx);
 		if (status != KDUMP_OK) {
-			fprintf(stderr, "kdump_bmp_find_clear faild: %s\n",
+			fprintf(stderr, "kdump_bmp_find_clear failed: %s\n",
 				kdump_bmp_get_err(bmp));
 			return -1;
 		}

--- a/python/addrxlat.c
+++ b/python/addrxlat.c
@@ -2321,7 +2321,7 @@ typedef struct {
 PyDoc_STRVAR(meth__doc__,
 "Method(kind) -> address translation method\n\
 \n\
-This is a generic base class for all translation desriptions.\n\
+This is a generic base class for all translation descriptions.\n\
 Use a subclass to get a more suitable interface to the parameters\n\
 of a specific translation kind.");
 


### PR DESCRIPTION
dumpattr: One occurence of 'failed' was misspelled 'faild'
addrxlat: desriptions => descriptions

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>