### PR TITLE
Fix  [-Wint-conversion] error caught by clang

### DIFF
--- a/python/kdumpfile.c
+++ b/python/kdumpfile.c
@@ -1446,7 +1446,7 @@ static PyTypeObject attr_dir_object_type =
 	sizeof(char),			/* tp_itemsize*/
 	/* methods */
 	attr_dir_dealloc,		/* tp_dealloc*/
-	attr_dir_print,			/* tp_print*/
+	0,				/* tp_print*/
 	0,				/* tp_getattr*/
 	0,				/* tp_setattr*/
 	0,				/* tp_compare*/


### PR DESCRIPTION
./kdumpfile.c:1449:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'int (PyObject *, FILE *, int)' (aka 'int (struct _object *, struct _IO_FILE *, int)') [-Wint-conversion]
        attr_dir_print,

This code was added in 2016, I don't know if the python API changed since then, or if this is just a cut and paste error, but according to the python docs[1], passing a function pointer here is incorrect.

[1] https://docs.python.org/3/c-api/typeobj.html