### PR TITLE
Create out folder before trying to write to it

### DIFF
--- a/tests/xlatmap-check
+++ b/tests/xlatmap-check
@@ -8,6 +8,8 @@ name=xlatmap
 resultfile="out/${name}.result"
 expectfile="$srcdir/$name.expect"
 
+mkdir -p out
+
 echo -n "Checking... "
 ./xlatmap >"$resultfile"
 rc=$?


### PR DESCRIPTION
The test `xlatmap-check` currently tries to write to the folder `out`, which does not exist without executing another test that creates this folder previously. This can lead to the test failing if the test is run standalone (via `env TESTS="xlatmap-check" make -e check`) or flaky test behaivior if the test suite is run in parallel (via `make -j16 check`).

Creating the folder in the test if it doesn't exist, like done in other tests, prevents this issue.