### PR TITLE
couple fixes in libkdumpfile python binding code

### DIFF
--- a/python/addrxlat.c
+++ b/python/addrxlat.c
@@ -1655,6 +1655,8 @@ ctx_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
 		if (copy_attr((PyObject*)self, "next_cb_get_page", "cb_get_page"))
 			goto err;
+		if (copy_attr((PyObject*)self, "next_read_caps", "cb_read_caps"))
+			goto err;
 		if (copy_attr((PyObject*)self, "next_cb_reg_value", "cb_reg_value"))
 			goto err;
 		if (copy_attr((PyObject*)self, "next_cb_sym_value", "cb_sym_value"))

--- a/python/addrxlat.c
+++ b/python/addrxlat.c
@@ -1899,7 +1899,7 @@ ctx_next_cb_read_caps(PyObject *_self, PyObject *args)
 	if (PyErr_Occurred())
 		return NULL;
 
-	result = Py_BuildValue("(k)", caps);
+	result = Py_BuildValue("k", caps);
 	if (!result)
 		return NULL;
 	return result;


### PR DESCRIPTION
Hi Petr,

Could you please merge these two fixes. I've run into these issues when
I tried my gdbserver on top of my latest code. This is a minimal test case
to reproduce the issues:

```
#!/usr/bin/env python3
import addrxlat
from kdumpfile import kdumpfile

# Test reads kernel vmcorefile and for given process pgd
#   * translates pgd address from kernel virtual addr to physical
#   * sets new rootpgt to that address so from now on it will have
#   the process's memory view

# test input data
vmcorefile = "vmcore"
# from any process task_struct mm->pgd i.e page table of some process
process_rootpgt = 18446639130142990336

kdump = kdumpfile(file=vmcorefile)
kdump.attr["addrxlat.ostype"] = "linux"

# translate process pgt kernel virtual address into physical
system = kdump.get_addrxlat_sys()
ctx = kdump.get_addrxlat_ctx()

fulladdr = addrxlat.FullAddress(addrxlat.KVADDR, process_rootpgt)
fulladdr.conv(addrxlat.KPHYSADDR, ctx, system)

# set our process rootpgt
system.os_init(ctx=ctx, arch="x86_64", os_type="linux", rootpgt=fulladdr)
```

Thanks,
Alexander