### PR TITLE
aarch64: introduce user_rootpgt param to read user space memory

### DIFF
--- a/include/libkdumpfile/addrxlat.h.in
+++ b/include/libkdumpfile/addrxlat.h.in
@@ -829,6 +829,11 @@ typedef enum _addrxlat_optidx {
 	 */
 	ADDRXLAT_OPT_rootpgt,
 
+	/** User land root page table address. Used *only* in aarch64 case.
+	 * Type: full address
+	 */
+	ADDRXLAT_OPT_user_rootpgt,
+
 	/** Xen p2m root machine frame number.
 	 * Type: address
 	 */
@@ -925,6 +930,14 @@ static inline void
 addrxlat_opt_rootpgt(addrxlat_opt_t *opt, const addrxlat_fulladdr_t *val)
 {
 	opt->idx = ADDRXLAT_OPT_rootpgt;
+	opt->val.fulladdr = *val;
+}
+
+/** Helper to set @xref ADDRXLAT_OPT_user_rootpgt in a type-safe manner. */
+static inline void
+addrxlat_opt_user_rootpgt(addrxlat_opt_t *opt, const addrxlat_fulladdr_t *val)
+{
+	opt->idx = ADDRXLAT_OPT_user_rootpgt;
 	opt->val.fulladdr = *val;
 }
 

--- a/python/addrxlat.c
+++ b/python/addrxlat.c
@@ -4312,13 +4312,14 @@ sys_os_init(PyObject *_self, PyObject *args, PyObject *kwargs)
 		"page_shift",
 		"phys_base",
 		"rootpgt",
+		"user_rootpgt",
 		"xen_p2m_mfn",
 		"xen_xlat",
 		NULL
 	};
 	PyObject *ctxobj;
 	PyObject *arch, *type, *ver, *page_shift, *phys_base,
-		*rootpgt, *xen_p2m_mfn, *xen_xlat, *phys_bits, *virt_bits;
+		*rootpgt, *user_rootpgt, *xen_p2m_mfn, *xen_xlat, *phys_bits, *virt_bits;
 	addrxlat_ctx_t *ctx;
 	addrxlat_opt_t opts[ADDRXLAT_OPT_NUM], *p;
 	addrxlat_status status;
@@ -4326,9 +4327,9 @@ sys_os_init(PyObject *_self, PyObject *args, PyObject *kwargs)
 	arch = type = ver = page_shift = phys_base = rootpgt =
 		xen_p2m_mfn = xen_xlat = phys_bits = virt_bits = Py_None;
 	if (!PyArg_ParseTupleAndKeywords(
-		    args, kwargs, "O|OOOOOOOOOO:os_init", keywords,
+		    args, kwargs, "O|OOOOOOOOOOO:os_init", keywords,
 		    &ctxobj, &arch, &type, &ver, &phys_bits, &virt_bits,
-		    &page_shift, &phys_base, &rootpgt, &xen_p2m_mfn,
+		    &page_shift, &phys_base, &rootpgt, &user_rootpgt, &xen_p2m_mfn,
 		    &xen_xlat))
 		return NULL;
 
@@ -4392,6 +4393,13 @@ sys_os_init(PyObject *_self, PyObject *args, PyObject *kwargs)
 		if (!faddr)
 			return NULL;
 		addrxlat_opt_rootpgt(p, faddr);
+		++p;
+	}
+	if (user_rootpgt != Py_None) {
+		addrxlat_fulladdr_t *faddr = fulladdr_AsPointer(user_rootpgt);
+		if (!faddr)
+			return NULL;
+		addrxlat_opt_user_rootpgt(p, faddr);
 		++p;
 	}
 	if (xen_p2m_mfn != Py_None) {

--- a/src/addrxlat/aarch64.c
+++ b/src/addrxlat/aarch64.c
@@ -404,6 +404,10 @@ map_linux_aarch64(struct os_init_data *ctl)
 			return status;
 	}
 
+	meth = &ctl->sys->meth[ADDRXLAT_SYS_METH_UPGT];
+	if (opt_isset(ctl->popt, user_rootpgt))
+		meth->param.pgt.root = ctl->popt.user_rootpgt;
+
 	status = sys_set_physmaps(ctl, PHYSADDR_MASK);
 	if (status != ADDRXLAT_OK)
 		return status;

--- a/src/addrxlat/addrxlat-priv.h
+++ b/src/addrxlat/addrxlat-priv.h
@@ -414,6 +414,7 @@ struct parsed_opts {
 	unsigned long page_shift;	/**< Value of OPT_page_shift. */
 	addrxlat_addr_t phys_base;	/**< Value of OPT_phys_base. */
 	addrxlat_fulladdr_t rootpgt;	/**< Value of OPT_rootpgt. */
+	addrxlat_fulladdr_t user_rootpgt;	/**< Value of OPT_user_rootpgt. */
 	unsigned long xen_p2m_mfn;	/**< Value of OPT_xen_p2m_mfn. */
 	bool xen_xlat;			/**< Value of OPT_xen_xlat. */
 };

--- a/src/addrxlat/sys.c
+++ b/src/addrxlat/sys.c
@@ -121,6 +121,10 @@ parse_opt(struct parsed_opts *popt, const addrxlat_opt_t *opt)
 		popt->rootpgt = opt->val.fulladdr;
 		break;
 
+	case ADDRXLAT_OPT_user_rootpgt:
+		popt->user_rootpgt = opt->val.fulladdr;
+		break;
+
 	case ADDRXLAT_OPT_xen_p2m_mfn:
 		popt->xen_p2m_mfn = opt->val.num;
 		break;


### PR DESCRIPTION
Hi Petr,

My libkdumpfile based gdbserver
https://github.com/AlexanderKamensky/libkdumpfile/tree/new_20230805/gdbserver#process
does not work with your latest code.

The issue that now I cannot set rootpgt to read user-land
memory. This patch addresses it by introducing user_rootpgt.

Thanks,
Alexander